### PR TITLE
🚧 Init database creation with SQL Server container

### DIFF
--- a/Database/Dockerfile.sqltools
+++ b/Database/Dockerfile.sqltools
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/mssql-tools
+
+COPY init-db.sql /init-db.sql
+
+ENTRYPOINT [ "bash", "-c", " \
+  echo '⏳ Waiting for SQL Server to be ready...'; \
+  sleep 20; \
+  echo '🚀 Running init-db.sql...'; \
+  /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P StrongP@ssw0rd -i /init-db.sql; \
+  echo '✅ Script executed successfully.' \
+"]

--- a/Database/init-db.sql
+++ b/Database/init-db.sql
@@ -1,0 +1,21 @@
+CREATE DATABASE TestDB;
+GO
+
+USE TestDB;
+GO
+
+CREATE TABLE DocKey (
+  Id INT IDENTITY(1,1) PRIMARY KEY,
+  DocName varchar(200) NOT NULL,
+  [Key] varchar(200) NOT NULL
+)
+GO
+
+CREATE TABLE LogProcess (
+  Id INT IDENTITY(1,1) PRIMARY KEY,
+  OriginalFileName varchar(200) NOT NULL,
+  Status varchar(200) NOT NULL,
+  NewFileName varchar(200),
+  DateProcess DATETIME2 NOT NULL
+)
+GO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: sqlserver
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=StrongP@ssw0rd
+    ports:
+      - "1433:1433"
+    networks:
+      - sqlnet
+    volumes:
+      - sqlserverdata:/var/opt/mssql 
+  sqltools:
+    build:
+      context: ./Database
+      dockerfile: Dockerfile.sqltools
+    container_name: sqltools
+    depends_on:
+      - sqlserver
+    networks:
+      - sqlnet
+
+networks:
+  sqlnet:
+
+volumes:
+  sqlserverdata:  
+


### PR DESCRIPTION
###  Pull Request Description
This Pull Request adds the initial database setup for the EQTAX project. It configures a SQL Server 2022 instance running in a Docker container, along with an automatic initialization script.

### Included Changes
- docker-compose.yml: defines the sqlserver and sqltools services, with persistent data volumes.
- database/init-db.sql: SQL script that creates the TestDB database and the DocKey and LogProcess tables.
- database/Dockerfile.sqltools: custom Docker image to automatically execute the SQL script on first run.
- Volume configuration to persist SQL Server data between container restarts.

